### PR TITLE
report Adapter errors to the store

### DIFF
--- a/src/ts/platforms/apple-appstore/appstore-adapter.ts
+++ b/src/ts/platforms/apple-appstore/appstore-adapter.ts
@@ -169,9 +169,7 @@ namespace CdvPurchase {
 
                         error: (code: ErrorCode, message: String, options?: { productId: string, quantity?: number }) => {
                             this.log.error('ERROR: ' + code + ' - ' + message);
-                            if (code === ErrorCode.PAYMENT_CANCELLED) {
-                                return;
-                            }
+                            CdvPurchase.store.triggerError(CdvPurchase.storeError(code, message));
                         },
 
                         ready: () => {


### PR DESCRIPTION
without this fix it's not possible to detect Adapter errors like PAYMENT_CANCELLED, since the Promise callback don't work (yet).

Changes proposed in this pull request:

-
-

---

To test this pull request with cordova:

```
# 1: Uninstall the plugin (if already installed)
cordova plugin rm cordova-plugin-purchase

# 2: Install from github
cordova plugin add "https://github.com/j3k0/cordova-plugin-purchase.git#BRANCH_NAME_HERE"
```
